### PR TITLE
feat: update action runtime to NodeJS 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
-      - uses: actions/checkout@v2
+          node-version: '16.x'
+      - uses: actions/checkout@v3
       - run: yarn install --frozen-lockfile --ignore-optional
       - run: yarn test
   latest:
@@ -27,10 +27,10 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
-      - uses: actions/checkout@v2
+          node-version: '16.x'
+      - uses: actions/checkout@v3
       - run: yarn install --frozen-lockfile --ignore-optional
       - run: yarn package
       - uses: ./
@@ -42,10 +42,10 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
-      - uses: actions/checkout@v2
+          node-version: '16.x'
+      - uses: actions/checkout@v3
       - run: yarn install --frozen-lockfile --ignore-optional
       - run: yarn package
       - uses: ./
@@ -59,10 +59,10 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
-      - uses: actions/checkout@v2
+          node-version: '16.x'
+      - uses: actions/checkout@v3
       - run: yarn install --frozen-lockfile --ignore-optional
       - run: yarn package
       - uses: ./
@@ -76,10 +76,10 @@ jobs:
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
-      - uses: actions/checkout@v2
+          node-version: '16.x'
+      - uses: actions/checkout@v3
       - run: yarn install --frozen-lockfile --ignore-optional
       - run: yarn package
       - uses: ./

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Install the latest version of the Pulumi CLI:
 
 ```yaml
 - name: Install Pulumi CLI
-  uses: pulumi/setup-pulumi@v2
+  uses: pulumi/setup-pulumi@v3
 ```
 
 Install a specific version of the Pulumi CLI:
 
 ```yaml
 - name: Install pulumi
-  uses: pulumi/setup-pulumi@v2
+  uses: pulumi/setup-pulumi@v3
   with:
     pulumi-version: 3.3.0
 ```
@@ -26,7 +26,7 @@ Install a version that adheres to a semver range
 
 ```yaml
 - name: Install pulumi
-  uses: pulumi/setup-pulumi@v2
+  uses: pulumi/setup-pulumi@v3
   with:
     pulumi-version: ^3.0.0
 ```

--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ branding:
   icon: 'terminal'
   color: 'purple'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-pulumi",
-  "version": "0.0.0",
+  "version": "3.0.0",
   "private": true,
   "description": "Setup the Pulumi CLI in a GitHub Actions build environment",
   "main": "dist/index.js",
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
-    "@types/node": "^12.11.6",
+    "@types/node": "^16.11.65",
     "@types/semver": "^7.3.4",
     "@vercel/ncc": "^0.24.0",
     "jest": "^26.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -739,10 +739,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.1.tgz#9b60797dee1895383a725f828a869c86c6caa5c2"
   integrity sha512-zyxJM8I1c9q5sRMtVF+zdd13Jt6RU4r4qfhTd7lQubyThvLfx6yYekWSQjGCGV2Tkecgxnlpl/DNlb6Hg+dmEw==
 
-"@types/node@^12.11.6":
-  version "12.20.14"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.14.tgz#9caf7eea0df08b406829889cc015256a6d81ab10"
-  integrity sha512-iFJOS5Q470FF+r4Ol2pSley7/wCNVqf+jgjhtxLLaJcDs+To2iCxlXIkJXrGLD9w9G/oJ9ibySu7z92DCwr7Pg==
+"@types/node@^16.11.65":
+  version "16.11.65"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.65.tgz#59500b86af757d6fcabd3dec32fecb6e357d7a45"
+  integrity sha512-Vfz7wGMOr4jbQGiQHVJm8VjeQwM9Ya7mHe9LtQ264/Epf5n1KiZShOFqk++nBzw6a/ubgYdB9Od7P+MH/LjoWw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: pulumi/setup-pulumi