### PR TITLE
README: Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,59 @@
 # Setup GitHub Action
 
+### Deprecation notice
+
+**Warning** This action has been deprecated.
+
+Please use the [pulumi/actions](https://github.com/pulumi/actions) action
+in [installation only mode](https://github.com/pulumi/actions#installation-only).
+</td></tr></table>
+
+#### Migrating to pulumi/actons
+
+To migrate, switch to `pulumi/actions@v4`.
+
+<table>
+<thead><tr><td>Before</td><td>After</td></tr></thead>
+<tbody>
+<tr><td>
+
+```yaml
+- name: Install pulumi
+  uses: pulumi/setup-pulumi@v2
+```
+
+---
+
+```yaml
+- name: Install pulumi
+  uses: pulumi/setup-pulumi@v2
+  with:
+    pulumi-version: 3.3.0
+```
+
+</td><td>
+
+```yaml
+- name: Install pulumi
+  uses: pulumi/actions@v4
+```
+
+---
+
+```yaml
+- name: Install pulumi
+  uses: pulumi/actions@v4
+  with:
+    pulumi-version: 3.3.0
+```
+
+</td></tr>
+
+</tbody>
+</table>
+
+## Introduction
+
 This repository contains an action for use with GitHub Actions, which installs a specified version of  the `pulumi` CLI.
 
 `pulumi` is installed into `/home/runner/.pulumi` (or equivalent on Windows) and the `bin` subdirectory is added to the PATH.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please use the [pulumi/actions](https://github.com/pulumi/actions) action
 in [installation only mode](https://github.com/pulumi/actions#installation-only).
 </td></tr></table>
 
-#### Migrating to pulumi/actons
+#### Migrating to pulumi/actions
 
 To migrate, switch to `pulumi/actions@v4`.
 


### PR DESCRIPTION
Now that pulumi/actions supports install-only workflows,
we can deprecate this action.

This adds a deprecation notice to the README,
pointing users to pulumi/actions instead
and providing instructions on how to migrate.

Refs pulumi/actions#686
